### PR TITLE
DAC6-2817: MDR Live Handover: Increase branch coverage to at least 90% for register-for-exchange-of-information-frontend

### DIFF
--- a/app/controllers/CheckYourAnswersController.scala
+++ b/app/controllers/CheckYourAnswersController.scala
@@ -85,16 +85,6 @@ class CheckYourAnswersController @Inject() (
         result         <- EitherT.right[ApiError](controllerHelper.updateSubscriptionIdAndCreateEnrolment(safeId, subscriptionID))
       } yield result)
         .valueOrF {
-          case EnrolmentExistsError(groupIds) if request.affinityGroup == Individual =>
-            logger.info(s"CheckYourAnswersController: EnrolmentExistsError for the groupIds $groupIds")
-            Future.successful(Redirect(routes.IndividualAlreadyRegisteredController.onPageLoad()))
-          case EnrolmentExistsError(groupIds) =>
-            logger.info(s"CheckYourAnswersController: EnrolmentExistsError for the groupIds $groupIds")
-            if (request.userAnswers.get(RegistrationInfoPage).isDefined) {
-              Future.successful(Redirect(routes.BusinessAlreadyRegisteredController.onPageLoadWithId()))
-            } else {
-              Future.successful(Redirect(routes.BusinessAlreadyRegisteredController.onPageLoadWithoutId()))
-            }
           case MandatoryInformationMissingError(_) =>
             logger.warn(s"CheckYourAnswersController: Mandatory information is missing")
             Future.successful(Redirect(routes.SomeInformationIsMissingController.onPageLoad()))

--- a/app/controllers/ContactEmailController.scala
+++ b/app/controllers/ContactEmailController.scala
@@ -18,7 +18,7 @@ package controllers
 
 import controllers.actions._
 import forms.ContactEmailFormProvider
-import models.{CheckMode, Mode}
+import models.Mode
 import navigation.ContactDetailsNavigator
 import pages.ContactEmailPage
 import play.api.i18n.{I18nSupport, MessagesApi}
@@ -49,10 +49,6 @@ class ContactEmailController @Inject() (
   def onPageLoad(mode: Mode): Action[AnyContent] =
     standardActionSets.identifiedUserWithData() {
       implicit request =>
-        if (mode == CheckMode) {
-          request.userAnswers.remove(ContactEmailPage)
-        }
-
         val preparedForm = request.userAnswers.get(ContactEmailPage) match {
           case None        => form
           case Some(value) => form.fill(value)

--- a/app/controllers/SndContactEmailController.scala
+++ b/app/controllers/SndContactEmailController.scala
@@ -18,7 +18,7 @@ package controllers
 
 import controllers.actions._
 import forms.SndContactEmailFormProvider
-import models.{CheckMode, Mode}
+import models.Mode
 import navigation.ContactDetailsNavigator
 import pages.SndContactEmailPage
 import play.api.i18n.{I18nSupport, MessagesApi}
@@ -49,10 +49,6 @@ class SndContactEmailController @Inject() (
   def onPageLoad(mode: Mode): Action[AnyContent] =
     standardActionSets.identifiedUserWithData() {
       implicit request =>
-        if (mode == CheckMode) {
-          request.userAnswers.remove(SndContactEmailPage)
-        }
-
         val preparedForm = request.userAnswers.get(SndContactEmailPage) match {
           case None        => form
           case Some(value) => form.fill(value)

--- a/app/forms/mappings/Constraints.scala
+++ b/app/forms/mappings/Constraints.scala
@@ -55,18 +55,6 @@ trait Constraints {
         }
     }
 
-  protected def inRange[A](minimum: A, maximum: A, errorKey: String)(implicit ev: Ordering[A]): Constraint[A] =
-    Constraint {
-      input =>
-        import ev._
-
-        if (input >= minimum && input <= maximum) {
-          Valid
-        } else {
-          Invalid(errorKey, minimum, maximum)
-        }
-    }
-
   protected def regexp(regex: String, errorKey: String): Constraint[String] =
     Constraint {
       case str if str.matches(regex) =>
@@ -99,11 +87,4 @@ trait Constraints {
         Valid
     }
 
-  protected def nonEmptySet(errorKey: String): Constraint[Set[_]] =
-    Constraint {
-      case set if set.nonEmpty =>
-        Valid
-      case _ =>
-        Invalid(errorKey)
-    }
 }

--- a/test/controllers/CheckYourAnswersControllerSpec.scala
+++ b/test/controllers/CheckYourAnswersControllerSpec.scala
@@ -112,6 +112,21 @@ class CheckYourAnswersControllerSpec extends SpecBase with ControllerMockFixture
 
       }
 
+      "must redirect to Information sent when UserAnswers is empty" in {
+
+        val userAnswers: UserAnswers = emptyUserAnswers
+
+        retrieveUserAnswersData(userAnswers)
+
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
+
+        val result = route(app, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustBe routes.InformationSentController.onPageLoad().url
+
+      }
+
       "must return OK and the correct view for a GET - First Contact without phone" in {
 
         val userAnswers: UserAnswers = UserAnswers(userAnswersId)
@@ -453,7 +468,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with ControllerMockFixture
         when(mockTaxEnrolmentsService.checkAndCreateEnrolment(any(), any(), any())(any(), any()))
           .thenReturn(Future.successful(Left(EnrolmentExistsError(GroupIds(Seq("id"), Seq.empty)))))
 
-        val userAnswers = UserAnswers("Id")
+        val userAnswers = UserAnswers("id")
           .set(DoYouHaveUniqueTaxPayerReferencePage, false)
           .success
           .value


### PR DESCRIPTION
CheckYourAnswers enrolment checks are tested but the code that runs is in the helper object so EnrolmentExistsError checks were redundant in CYA and have been removed

The remove ContactEmail check wasn't doing anything as the object returned by the remove is just discarded and due to immutability the page value is not being removed from the request object

Added one test for the CheckSubmission action 

Removed unused constraints to get statement coverage above 90%

