### PR TITLE
DAC6-2869: Only auto-match org for CT-UTR

### DIFF
--- a/app/controllers/IndexController.scala
+++ b/app/controllers/IndexController.scala
@@ -42,7 +42,7 @@ class IndexController @Inject() (
     with I18nSupport
     with Logging {
 
-  def onPageLoad(): Action[AnyContent] = standardActionSets.identifiedUserWithEnrolmentCheck().async {
+  def onPageLoad(): Action[AnyContent] = standardActionSets.identifiedUserWithEnrolmentCheckAndCtUtrRetrieval().async {
     implicit request =>
       request.utr match {
         case Some(utr) =>

--- a/app/controllers/actions/CtUtrRetrievalAction.scala
+++ b/app/controllers/actions/CtUtrRetrievalAction.scala
@@ -18,7 +18,7 @@ package controllers.actions
 
 import config.FrontendAppConfig
 import models.requests.IdentifierRequest
-import models.{IdentifierType, UniqueTaxpayerReference}
+import models.{IdentifierType, NormalMode, UniqueTaxpayerReference}
 import play.api.Logging
 import play.api.mvc.Results.Redirect
 import play.api.mvc.{ActionFunction, Result}
@@ -54,8 +54,8 @@ class CtUtrRetrievalActionProvider @Inject() (
       case (AffinityGroup.Organisation, Some(_)) =>
         block(request.copy(utr = ctUtr))
       case (_, Some(_)) =>
-        logger.error("IR-CT UTR is only allowed for affinity group Organisation")
-        Future.successful(Redirect(controllers.routes.ThereIsAProblemController.onPageLoad()))
+        logger.warn("IR-CT UTR found for affinity group other than Organisation")
+        Future.successful(Redirect(controllers.routes.ReporterTypeController.onPageLoad(NormalMode)))
       case _ =>
         block(request)
     }

--- a/app/controllers/actions/StandardActionSets.scala
+++ b/app/controllers/actions/StandardActionSets.scala
@@ -32,8 +32,11 @@ class StandardActionSets @Inject() (identify: IdentifierAction,
                                     dependantAnswer: DependantAnswerProvider
 ) {
 
-  def identifiedUserWithEnrolmentCheck(): ActionBuilder[IdentifierRequest, AnyContent] =
+  def identifiedUserWithEnrolmentCheckAndCtUtrRetrieval(): ActionBuilder[IdentifierRequest, AnyContent] =
     identify() andThen checkEnrolment() andThen retrieveCtUTR()
+
+  def identifiedUserWithEnrolmentCheck(): ActionBuilder[IdentifierRequest, AnyContent] =
+    identify() andThen checkEnrolment()
 
   def identifiedUserWithInitializedData(): ActionBuilder[DataRequest, AnyContent] =
     identifiedUserWithEnrolmentCheck() andThen getData() andThen initializeData()

--- a/test/controllers/actions/CtUtrRetrievalActionSpec.scala
+++ b/test/controllers/actions/CtUtrRetrievalActionSpec.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import base.SpecBase
+import config.FrontendAppConfig
+import models.IdentifierType
+import models.requests.IdentifierRequest
+import org.scalatest.prop.TableDrivenPropertyChecks
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc.Result
+import play.api.mvc.Results.{Ok, Redirect}
+import play.api.test.FakeRequest
+import uk.gov.hmrc.auth.core.{AffinityGroup, Enrolment, EnrolmentIdentifier}
+
+import scala.concurrent.Future
+
+class CtUtrRetrievalActionSpec extends SpecBase with TableDrivenPropertyChecks {
+
+  private val fakeRequest = FakeRequest("", "")
+
+  private def block[A]: IdentifierRequest[A] => Future[Result] = (_: IdentifierRequest[A]) => {
+    Future.successful(Ok)
+  }
+
+  private val applicationBuilder       = new GuiceApplicationBuilder()
+  private val action                   = applicationBuilder.injector.instanceOf[CtUtrRetrievalActionProvider]
+  private val config                   = applicationBuilder.injector.instanceOf[FrontendAppConfig]
+  private val ctUtrEnrolmentIdentifier = EnrolmentIdentifier(IdentifierType.UTR, utr.uniqueTaxPayerReference)
+
+  "CT UTR Retrieval Action" - {
+
+    "when the affinity group is Organisation" - {
+
+      val affinityGroup = AffinityGroup.Organisation
+
+      "must execute request block when CT-UTR enrolment exists" in {
+        val ctUtrEnrolment    = Enrolment(config.ctEnrolmentKey, Seq(ctUtrEnrolmentIdentifier), state = "")
+        val identifierRequest = IdentifierRequest(fakeRequest, UserAnswersId, affinityGroup, enrolments = Set(ctUtrEnrolment))
+
+        val result = action.invokeBlock(identifierRequest, block)
+
+        result.futureValue mustBe Ok
+      }
+
+      "must execute request block when CT-UTR enrolment does not exists" in {
+        val identifierRequest = IdentifierRequest(fakeRequest, UserAnswersId, affinityGroup, enrolments = Set.empty)
+
+        val result = action.invokeBlock(identifierRequest, block)
+
+        result.futureValue mustBe Ok
+      }
+    }
+
+    val nonOrganisationAffinityGroups = Table(
+      "affinityGroup",
+      AffinityGroup.Individual,
+      AffinityGroup.Agent
+    )
+
+    forAll(nonOrganisationAffinityGroups) {
+      affinityGroup =>
+        s"when the affinity group is $affinityGroup" - {
+
+          "must redirect to ThereIsAProblemPage when CT-UTR enrolment exists" in {
+            val ctUtrEnrolment    = Enrolment(config.ctEnrolmentKey, Seq(ctUtrEnrolmentIdentifier), state = "")
+            val identifierRequest = IdentifierRequest(fakeRequest, UserAnswersId, affinityGroup, enrolments = Set(ctUtrEnrolment))
+
+            val result = action.invokeBlock(identifierRequest, block)
+
+            result.futureValue mustBe Redirect(controllers.routes.ThereIsAProblemController.onPageLoad())
+          }
+
+          "must execute request block when CT-UTR enrolment does not exists" in {
+            val identifierRequest = IdentifierRequest(fakeRequest, UserAnswersId, affinityGroup, enrolments = Set.empty)
+
+            val result = action.invokeBlock(identifierRequest, block)
+
+            result.futureValue mustBe Ok
+          }
+        }
+    }
+
+  }
+
+}

--- a/test/controllers/actions/CtUtrRetrievalActionSpec.scala
+++ b/test/controllers/actions/CtUtrRetrievalActionSpec.scala
@@ -18,7 +18,7 @@ package controllers.actions
 
 import base.SpecBase
 import config.FrontendAppConfig
-import models.IdentifierType
+import models.{IdentifierType, NormalMode}
 import models.requests.IdentifierRequest
 import org.scalatest.prop.TableDrivenPropertyChecks
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -76,13 +76,13 @@ class CtUtrRetrievalActionSpec extends SpecBase with TableDrivenPropertyChecks {
       affinityGroup =>
         s"when the affinity group is $affinityGroup" - {
 
-          "must redirect to ThereIsAProblemPage when CT-UTR enrolment exists" in {
+          "must redirect to ReporterTypePage when CT-UTR enrolment exists" in {
             val ctUtrEnrolment    = Enrolment(config.ctEnrolmentKey, Seq(ctUtrEnrolmentIdentifier), state = "")
             val identifierRequest = IdentifierRequest(fakeRequest, UserAnswersId, affinityGroup, enrolments = Set(ctUtrEnrolment))
 
             val result = action.invokeBlock(identifierRequest, block)
 
-            result.futureValue mustBe Redirect(controllers.routes.ThereIsAProblemController.onPageLoad())
+            result.futureValue mustBe Redirect(controllers.routes.ReporterTypeController.onPageLoad(NormalMode))
           }
 
           "must execute request block when CT-UTR enrolment does not exists" in {

--- a/test/controllers/actions/FakeCtUtrRetrievalAction.scala
+++ b/test/controllers/actions/FakeCtUtrRetrievalAction.scala
@@ -26,16 +26,16 @@ class FakeCtUtrRetrievalActionProvider(
   utr: Option[UniqueTaxpayerReference] = None
 ) extends CtUtrRetrievalAction {
 
-  def apply(): ActionTransformer[IdentifierRequest, IdentifierRequest] =
+  def apply(): ActionFunction[IdentifierRequest, IdentifierRequest] =
     new FakeCtUtrRetrievalAction(utr)
 }
 
 class FakeCtUtrRetrievalAction(
   utr: Option[UniqueTaxpayerReference] = None
-) extends ActionTransformer[IdentifierRequest, IdentifierRequest] {
+) extends ActionFunction[IdentifierRequest, IdentifierRequest] {
 
-  override protected def transform[A](request: IdentifierRequest[A]): Future[IdentifierRequest[A]] =
-    Future.successful(request.copy(utr = utr))
+  override def invokeBlock[A](request: IdentifierRequest[A], block: IdentifierRequest[A] => Future[Result]): Future[Result] =
+    block(request.copy(utr = utr))
 
   implicit override protected val executionContext: ExecutionContext =
     scala.concurrent.ExecutionContext.Implicits.global


### PR DESCRIPTION
This change ensures that only the Organisation affinity group is allowed to be auto-matched using a Corporation Tax UTR.
When we encounter a request where the above is not met, we log a warning and redirect the user to ReporterType page.