### PR TITLE
DAC6-2998[BUG]: Autocomplete visual bug

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,6 +39,6 @@ body:not(.js-enabled) .js-enabled {
 // important to do this on the wrapper rather than the input itself otherwise the down-arrow will be floating by itself
 @media (min-width: 40.0625em){
   .autocomplete__wrapper {
-    width: 62%!important;
+    width: 66.66%!important;
   }
 }


### PR DESCRIPTION
- Adjust autocomplete wrapper width to fit long country names
- 66.66% was chosen to match other address fields

<img width="451" alt="image" src="https://github.com/hmrc/register-for-exchange-of-information-frontend/assets/77161245/edfe46ed-2205-4410-8f60-e1dc775827f2">
